### PR TITLE
scripts/initcpio-run.m4: use /usr/bin/ash in shebang

### DIFF
--- a/scripts/initcpio-run.m4
+++ b/scripts/initcpio-run.m4
@@ -1,7 +1,8 @@
 m4_define(`m4_PROMPT_NEVER', 0)m4_dnl
 m4_define(`m4_PROMPT_ONCE', 1)m4_dnl
 m4_define(`m4_PROMPT_ALWAYS', 2)m4_dnl
-#!/bin/sh
+#!/usr/bin/ash
+# shellcheck shell=dash
 
 # Include a UUID, so this value should never appear otherwise
 undefined="undefined 110d43d6-f20a-4f29-bae4-1a58f813980c"


### PR DESCRIPTION
All initramfs initcpio hooks in Arch Linux use `/usr/bin/ash` in shebang so use it here as well for consistence. Also silence shellcheck warning.