### PR TITLE
Makefile/man: fix typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # khefin Makefile
 #
-# Comments beginning with #: and imediately preceding a target are printed by the `help` target.
+# Comments beginning with #: and immediately preceding a target are printed by the `help` target.
 
 
 ################################################################################

--- a/man/1/khefin-ssh-askpass.m4
+++ b/man/1/khefin-ssh-askpass.m4
@@ -13,7 +13,7 @@ This is a Bash script that can be used as a drop-in replacement for \fBssh-askpa
 It works by having a passphrase for each SSH key derived using \fB`'m4_APPNAME generate\fR and based on the SSH key's fingerprint.
 
 For this to work, you will need to set \fIssh-keyfile\fR's password to the output of \fB`'m4_APPNAME-ssh-askpass get-passphrase\fI ssh-keyfile\fR.
-You may use \fBssh-keygen -p -f \fIssh-keyfile\fB -N "$(m4_APPNAME-ssh-askpass get-passphrase \fIssh-keyfile\fB)"\fR to do this, however be aware that this will make the passphrase (briefly) availble to other users on the system, who can inspect the command line for \fBssh-keygen\fR.
+You may use \fBssh-keygen -p -f \fIssh-keyfile\fB -N "$(m4_APPNAME-ssh-askpass get-passphrase \fIssh-keyfile\fB)"\fR to do this, however be aware that this will make the passphrase (briefly) available to other users on the system, who can inspect the command line for \fBssh-keygen\fR.
 
 Once that is done, you will need to set the \fBSSH_ASKPASS\fR environment variable to the path to \fB`'m4_APPNAME-ssh-askpass\fR so that \fBssh-agent\fR(1) knows to call it.
 
@@ -36,7 +36,7 @@ In particular, the following ways of calling this script are supported:
 
 .TP
 .BR m4_SSH_ASKPASS_ENCRYPTED_KEYFILE_ENV
-Path to the encrypted keyfile to use ot protect SSH keys.
+Path to the encrypted keyfile to use to protect SSH keys.
 Defaults to \fB`'m4_SSH_ASKPASS_DEFAULT_ENCRYPTED_KEYFILE\fR.
 
 .TP

--- a/man/1/khefin.m4
+++ b/man/1/khefin.m4
@@ -21,7 +21,7 @@ print version and exit.
 show a list of authenticator devices currently connected.
 
 .B enrol
-create or overwrite \fIfile\fR with randomly\-generated data required to produce a secret for the given \fIpassphrase\fR, using \fIdeivce\fR.
+create or overwrite \fIfile\fR with randomly\-generated data required to produce a secret for the given \fIpassphrase\fR, using \fIdevice\fR.
 
 .B generate
 generate an HMAC across the data contained in \fIfile\fR, once it has been decrypted with the given \fIpassphrase\fR.


### PR DESCRIPTION
This commit fixes some typos found in the man pages found while reading
and in Makefile found using 'codespell'.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>